### PR TITLE
fix rtd badge URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Introduction
 ============
 
 
-.. image:: https://readthedocs.org/projects/adafruit-circuitpython-neopxl8/badge/?version=latest
+.. image:: https://readthedocs.org/projects/neopxl8/badge/?version=latest
     :target: https://docs.circuitpython.org/projects/neopxl8/en/latest/
     :alt: Documentation Status
 


### PR DESCRIPTION
This project's slug on RTD is just `neopxl8` https://app.readthedocs.org/projects/neopxl8/builds/

adabot parses readme.rst for this slug in order to know where to fetch info from the RTD api at as well so this being mismatched causes adabot not to find valid adata about this project's docs when it runs reports. First noticed in: https://github.com/adafruit/adabot/pull/394